### PR TITLE
🐛 Fix : 유저 정보 수정 시 이미지 파일 업로드 오류

### DIFF
--- a/src/main/java/com/fluffygram/newsfeed/domain/Image/repository/ImageRepository.java
+++ b/src/main/java/com/fluffygram/newsfeed/domain/Image/repository/ImageRepository.java
@@ -20,10 +20,10 @@ public interface ImageRepository extends JpaRepository<Image, Long>{
         return GetImage.getImage(Const.USER_IMAGE_STORAGE, imageUrl);
     }
 
-    Optional<Image> findUserImageByStatusId(Long id);
+    Optional<Image> findImageByStatusIdAndStatus(Long id, ImageStatus status);
 
-    default Image getUserImageByIdOrElseThrow(Long id){
-        return findUserImageByStatusId(id).orElseThrow(()-> new NotFoundByIdException(ExceptionType.FILE_NOT_FOUND));
+    default Image getImageByIdOrElseThrow(Long id, ImageStatus status){
+        return findImageByStatusIdAndStatus(id, status).orElseThrow(()-> new NotFoundByIdException(ExceptionType.FILE_NOT_FOUND));
     }
 
     List<Image> findAllByStatusIdAndStatus(Long id, ImageStatus status);

--- a/src/main/java/com/fluffygram/newsfeed/domain/Image/service/ImageService.java
+++ b/src/main/java/com/fluffygram/newsfeed/domain/Image/service/ImageService.java
@@ -66,7 +66,7 @@ public class ImageService {
 
         String DBfileName = UploadImage.uploadUserImage(status.getPath(), multipartFile);
 
-        Image image = imageRepository.getUserImageByIdOrElseThrow(statusId);
+        Image image = imageRepository.getImageByIdOrElseThrow(statusId, status);
 
         image.updateFileName(multipartFile.getOriginalFilename());
         image.updateDBFileName(DBfileName);


### PR DESCRIPTION
statusId가 유저와 게시물이 겹치면 유저의 이미지 정보만 가지고 와야되는데 게시물의 이미지 정도도 가져오게 되서 오류가 발생했다. status도 확인해서 유저의 이미지만 가져오게 수정하였다.